### PR TITLE
Picture of the Day Page Styling Changes & Team Footer Section

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -2,7 +2,7 @@
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 .header {
   width: calc(100% - 50px);
-  height: 50px;
+  height: 75px;
   background-color: #1E88E5;
   color: #F5F5F5;
   display: flex;
@@ -149,22 +149,20 @@ a {
 
 .container {
   width: 80%;
-  height: auto;
-  margin: auto;
-  margin-bottom: 10em;
-  margin-top: 5em; }
+  margin: 40px auto; }
   .container .iframe-container {
     margin-left: auto;
     margin-right: auto;
     text-align: center;
-    padding: 2em; }
-    .container .iframe-container img {
-      max-width: 600px;
-      height: auto; }
+    padding: 2em;
+    max-width: 600px; }
+    .container .iframe-container .daily-media {
+      width: 100%; }
   .container h2, .container h3 {
     text-align: center; }
-  .container h3 {
-    padding-top: 1em; }
+  .container h2 {
+    line-height: 1.4;
+    padding-bottom: 15px; }
   .container hr {
     width: 60%; }
   .container .description img {
@@ -179,7 +177,12 @@ a {
     width: 60%;
     margin-left: auto;
     margin-right: auto;
-    line-height: 1.6; }
+    line-height: 1.6;
+    text-align: center; }
+
+@media (max-width: 767px) {
+  .container .description p {
+    width: 100%; } }
 
 .reddit-container {
   background-color: #263238;

--- a/client/src/Footer.js
+++ b/client/src/Footer.js
@@ -20,11 +20,11 @@ class Footer extends Component {
           <li><a href="#">Github</a></li>
         </ul>
         <ul className="footer-section">
-          <h3>Blah</h3>
-          <li><a href="#">One</a></li>
-          <li><a href="#">Two</a></li>
-          <li><a href="#">Three</a></li>
-          <li><a href="#">Four</a></li>
+          <h3>Team</h3>
+            <li><a href="https://github.com/michaelgee22" target="_blank">michaelgee22</a></li>
+            <li><a href="https://github.com/Nicknyr" target="_blank">nicknyr</a></li>
+            <li><a href="https://github.com/sam4815" target="_blank">sam4815</a></li>
+            <li><a href="https://github.com/SharpEleven91" target="_blank">sharpeleven11</a></li>
         </ul>
         </div>
       </div>

--- a/client/src/PictureOfTheDay.js
+++ b/client/src/PictureOfTheDay.js
@@ -12,11 +12,10 @@ class PictureOfTheDay extends Component {
     const media = this.props.pod.podData.url;
     // generates html tag from media type
     const tag = this.props.pod.podData.media_type === "video" ?
-                  <iframe type="text/html"
-                          width="600"
+                  <iframe className="daily-media" type="text/html"
                           height="400"
                           src={media} /> :
-                   <img src={media}/>
+                   <img className="daily-media" src={media}/>
 
     const data = pod.podData;
     const d = new Date();

--- a/client/style/_Header.scss
+++ b/client/style/_Header.scss
@@ -20,7 +20,6 @@
         color: $highlight-color;
       }
     }
-
   }
 
   .menu-btn {

--- a/client/style/_Header.scss
+++ b/client/style/_Header.scss
@@ -1,6 +1,6 @@
 .header {
   width: calc(100% - 50px);
-  height: 50px;
+  height: 75px;
   background-color: #1E88E5;
   color: #F5F5F5;
   display: flex;

--- a/client/style/_PictureOfTheDay.scss
+++ b/client/style/_PictureOfTheDay.scss
@@ -1,20 +1,16 @@
-
 .container {
   width: 80%;
-  height: auto;
-  margin: auto;
-  margin-bottom: 10em;
-  margin-top: 5em;
+  margin: 40px auto;
 
   .iframe-container {
     margin-left: auto;
     margin-right: auto;
     text-align: center;
     padding: 2em;
+    max-width: 600px;
 
-    img {
-      max-width: 600px;
-      height: auto;
+    .daily-media {
+      width: 100%;
     }
   }
 
@@ -22,8 +18,9 @@
     text-align: center;
   }
 
-  h3 {
-    padding-top: 1em;
+  h2 {
+    line-height: 1.4;
+    padding-bottom: 15px;
   }
 
   hr {
@@ -46,6 +43,17 @@
       margin-left: auto;
       margin-right: auto;
       line-height: 1.6;
+      text-align: center;
+    }
+  }
+}
+
+@media(max-width: 767px) {
+  .container {
+    .description {
+      p {
+        width: 100%;
+      }
     }
   }
 }


### PR DESCRIPTION
- I changed the header bar back to 75px because I think it doesn't look as crowded (but can change back to 50px if you guys think 50 is better)

- Condensed the excessive space in Picture of the Day Page and made page fully responsive

- Added team footer section with all our GitHub accounts linked in alphabetical order.

